### PR TITLE
Checks that the given selector is an object.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,6 +134,10 @@ export default class StyleBridge {
     }
 
     getDocumentSheet() {
-        return document.querySelector(this.selectorText).sheet;
+        const element = typeof this.selectorText === 'object'
+            ? this.selectorText
+            : document.querySelector(this.selectorText);
+
+        return element.sheet;
     }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -253,5 +253,13 @@ describe('StyleBrige', () => {
                 should(bridge.getDocumentSheet().constructor.name).equal('CSSStyleSheet');
             });
         });
+
+        it('should accept a htmlelement.', () => {
+            window.addEventListener('load', () => {
+                const bridge = new StyleBridge(document.getElementById('#stylesheet'), { desktop: null });
+
+                should(bridge.getDocumentSheet().constructor.name).equal('CSSStyleSheet');
+            });
+        });
     });
 });


### PR DESCRIPTION
This enables to pass the htmlobject itself to the constructor instead of a query-string.