### PR TITLE
Freeze rules object.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ export default class StyleBridge {
     constructor(selectorText, queryList = {}) {
         this.selectorText = selectorText;
         this.queryList = new QueryList(queryList);
-        this.rules = new RuleList();
+        this.rules = Object.freeze(new RuleList());
     }
 
     parse() {


### PR DESCRIPTION
Freeze the rules object to prevent Vue (or other reactive frameworks) to "observe" the object.
This dramatically speeds-up the rule generation/reading.